### PR TITLE
Fix: dependencies and project file being tracked with git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vs/
+bin/
+obj/
+*.sln


### PR DESCRIPTION
### Why:

- The amazing [Getting Started instructions](https://github.com/Shushishtok/AtS-my-first-mod/blob/master/Getting%20Started.md) do not go over setting up a .gitignore file and they probably shouldn't for brevity's sake/staying focused on modding
- Pushing all the dependencies and various Visual Studio files seems wasteful and potentially confusing

### What:

- Adds a .gitignore that hides files that are not necessary for working on the project - they will get regenerated